### PR TITLE
Handle unconventional millis/micros

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -361,7 +361,7 @@ function toPrimitive_TIMESTAMP_MILLIS(value) {
 }
 
 function fromPrimitive_TIMESTAMP_MILLIS(value) {
-  return new Date(+value);
+  return new Date(parseInt(value));
 }
 
 function toPrimitive_TIMESTAMP_MICROS(value) {
@@ -382,7 +382,13 @@ function toPrimitive_TIMESTAMP_MICROS(value) {
 }
 
 function fromPrimitive_TIMESTAMP_MICROS(value) {
-  return new Date(parseInt(value / 1000n));
+  if (value === undefined) {
+    return new Date(Nan);
+  } else if (typeof value === 'bigint') {
+    return new Date(parseInt(value / 1000n));
+  } else {
+    return new Date(value / 1000);
+  }
 }
 
 function toPrimitive_INTERVAL(value) {


### PR DESCRIPTION
We found that parquet files created from pyarrow have "unconventional" format for millis and micros. This change is not original it's a merge of 2 already proposed  PRs
https://github.com/ZJONSSON/parquetjs/pull/65
https://github.com/ZJONSSON/parquetjs/pull/45

We are struggling with those issues, it this something you will consider to merge? we can create our own fork but we believe is better having one library.